### PR TITLE
Fix preprocessing loading bug

### DIFF
--- a/spam_filter/train_text_model.py
+++ b/spam_filter/train_text_model.py
@@ -8,9 +8,9 @@ from sklearn.feature_extraction.text import TfidfTransformer
 from sklearn.linear_model import SGDClassifier
 
 
-
-from data_processing import load_train_test_classes, load_train_test_docs, \
-    Lemmatizer, DocCreator
+from data_processing.preprocessing import load_train_test_classes, \
+    load_train_test_docs
+from data_processing import Lemmatizer, DocCreator
 
 
 # Load the data


### PR DESCRIPTION
I realized that when setting up the packaging of data_processing for deployment, I missed an errant reference to the `load_train_test_docs` function. It needs to be loaded from the preprocessing submodule directly.